### PR TITLE
Continue to hydrate remaining relationships even if schema is partly defined

### DIFF
--- a/src/Repository/Traits/EntityHydrator.php
+++ b/src/Repository/Traits/EntityHydrator.php
@@ -102,7 +102,7 @@ trait EntityHydrator
             }
 
             if (!$entitySchema->properties->has($property)) {
-                return $entity;
+                continue;
             }
 
             $field = $entitySchema->properties->get($property);


### PR DESCRIPTION
If we don't want to hydrate fully specified entities then skip missing schema relationship and continue hydrating without the missing schema properties.